### PR TITLE
add link to existing documentation sphinx html sites

### DIFF
--- a/device-plugins/fpga.rst
+++ b/device-plugins/fpga.rst
@@ -1,2 +1,6 @@
 FPGA Device Plugin
 ##########################################
+
+`Documentation Page <https://intel.github.io/intel-device-plugins-for-kubernetes/README.html#fpga-device-plugin>`__
+
+Return to `Intel FPGA Device Plugin project on 01.org <https://01.org/kubernetes/projects/intel%C2%AE-fpga-device-plugin>`__

--- a/device-plugins/gpu.rst
+++ b/device-plugins/gpu.rst
@@ -1,2 +1,6 @@
 GPU Device Plugin
 ##########################################
+
+`Documentation Page <https://intel.github.io/intel-device-plugins-for-kubernetes/README.html#gpu-device-plugin>`__
+
+Return to `Intel GPU Device Plugin project on 01.org <https://01.org/kubernetes/projects/intel%C2%AE-gpu-device-plugin>`__

--- a/device-plugins/index.rst
+++ b/device-plugins/index.rst
@@ -11,6 +11,7 @@ The intent of this documentation is to help developers/users understand how to e
    fpga
    qat
    vpu
+   sgx
 
 Device Management in Kubernetes
 ===========================================

--- a/device-plugins/qat.rst
+++ b/device-plugins/qat.rst
@@ -1,2 +1,6 @@
 QuickAssist Technology Device Plugin
 ##########################################
+
+`Documentation Page <https://intel.github.io/intel-device-plugins-for-kubernetes/README.html#qat-device-plugin>`__
+
+Return to `Intel QAT Device Plugin project on 01.org <https://01.org/kubernetes/projects/intel%C2%AE-qat-device-plugin>`__

--- a/device-plugins/sgx.rst
+++ b/device-plugins/sgx.rst
@@ -1,0 +1,4 @@
+SGX Device Plugin
+##########################################
+
+`Documentation Page <https://intel.github.io/intel-device-plugins-for-kubernetes/README.html#sgx-device-plugin>`__

--- a/device-plugins/vpu.rst
+++ b/device-plugins/vpu.rst
@@ -1,2 +1,4 @@
 VPU Device Plugin
 ##########################################
+
+`Documentation Page <https://intel.github.io/intel-device-plugins-for-kubernetes/README.html#vpu-device-plugin>`__

--- a/index.rst
+++ b/index.rst
@@ -16,6 +16,7 @@ In this site, you will find detailed documentation and technical guides of each 
 
    nfd/index
    device-plugins/index
+   pmem-csi/index
    cpu-manager/index
    cri-manager/index
    cni/index

--- a/pmem-csi/index.rst
+++ b/pmem-csi/index.rst
@@ -1,0 +1,6 @@
+PMEM-CSI for Kubernetes
+##########################################
+
+`Documentation Page <https://intel.github.io/pmem-csi/latest/README.html>`__
+
+Return to `PMEM-CSI project on 01.org <https://01.org/kubernetes/projects/persistent-memory-pmem-csi>`__


### PR DESCRIPTION
Per discussion, we are adding links to existing projects' documentation sites and keeping this site to host documentations that do not have a permanent home yet.